### PR TITLE
fix: use proper format for scheme source

### DIFF
--- a/Lib.AspNetCore.Security/Http/Headers/ContentSecurityPolicySourceListBuilder.cs
+++ b/Lib.AspNetCore.Security/Http/Headers/ContentSecurityPolicySourceListBuilder.cs
@@ -24,12 +24,12 @@ namespace Lib.AspNetCore.Security.Http.Headers
         private bool _withStrictDynamicKeyword = false;
 
         private const string _sourceSeparator = " ";
-        private const string _httpSource = "http" + _sourceSeparator;
-        private const string _httpsSource = "https" + _sourceSeparator;
-        private const string _dataSource = "data" + _sourceSeparator;
-        private const string _mediastreamSource = "mediastream" + _sourceSeparator;
-        private const string _blobSource = "blob" + _sourceSeparator;
-        private const string _filesystemSource = "filesystem" + _sourceSeparator;
+        private const string _httpSource = "http:" + _sourceSeparator;
+        private const string _httpsSource = "https:" + _sourceSeparator;
+        private const string _dataSource = "data:" + _sourceSeparator;
+        private const string _mediastreamSource = "mediastream:" + _sourceSeparator;
+        private const string _blobSource = "blob:" + _sourceSeparator;
+        private const string _filesystemSource = "filesystem:" + _sourceSeparator;
         private const string _selfSource = ContentSecurityPolicyHeaderValue.SelfSource + _sourceSeparator;
         private const string _unsafeEvalSource = ContentSecurityPolicyHeaderValue.UnsafeEvalSource + _sourceSeparator;
         private const string _unsafeInlineSource = "'unsafe-inline'" + _sourceSeparator;


### PR DESCRIPTION
As per https://www.w3.org/TR/CSP3/#grammardef-scheme-source - scheme source must have `:` at the end:
```
; Schemes: "https:" / "custom-scheme:" / "another.custom-scheme:"
scheme-source = scheme-part ":"
```

I hope this PR fixes it